### PR TITLE
Replacing community keyworkd with the buildpacks keyword

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @paketo-community/stacks-maintainers
+* @paketo-buildpacks/stacks-maintainers

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -69,7 +69,7 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 					HaveKeyWithValue("io.buildpacks.stack.distro.name", "rhel"),
 					HaveKeyWithValue("io.buildpacks.stack.distro.version", MatchRegexp(`9\.\d+`)),
 					HaveKeyWithValue("io.buildpacks.stack.homepage", "https://github.com/paketo-buildpacks/ubi9-base-stack"),
-					HaveKeyWithValue("io.buildpacks.stack.maintainer", "Paketo Community"),
+					HaveKeyWithValue("io.buildpacks.stack.maintainer", "Paketo Buildpacks"),
 					HaveKeyWithValue("io.buildpacks.stack.metadata", MatchJSON("{}")),
 				))
 
@@ -116,7 +116,7 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 					HaveKeyWithValue("io.buildpacks.stack.distro.name", "rhel"),
 					HaveKeyWithValue("io.buildpacks.stack.distro.version", MatchRegexp(`9\.\d+`)),
 					HaveKeyWithValue("io.buildpacks.stack.homepage", "https://github.com/paketo-buildpacks/ubi9-base-stack"),
-					HaveKeyWithValue("io.buildpacks.stack.maintainer", "Paketo Community"),
+					HaveKeyWithValue("io.buildpacks.stack.maintainer", "Paketo Buildpacks"),
 					HaveKeyWithValue("io.buildpacks.stack.metadata", MatchJSON("{}")),
 				))
 

--- a/stacks/stack-java-11/stack.toml
+++ b/stacks/stack-java-11/stack.toml
@@ -1,6 +1,6 @@
 id = "io.buildpacks.stacks.ubi9"
 homepage = "https://github.com/paketo-buildpacks/ubi9-base-stack"
-maintainer = "Paketo Community"
+maintainer = "Paketo Buildpacks"
 
 platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
 

--- a/stacks/stack-java-17/stack.toml
+++ b/stacks/stack-java-17/stack.toml
@@ -1,6 +1,6 @@
 id = "io.buildpacks.stacks.ubi9"
 homepage = "https://github.com/paketo-buildpacks/ubi9-base-stack"
-maintainer = "Paketo Community"
+maintainer = "Paketo Buildpacks"
 
 platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
 

--- a/stacks/stack-java-21/stack.toml
+++ b/stacks/stack-java-21/stack.toml
@@ -1,6 +1,6 @@
 id = "io.buildpacks.stacks.ubi9"
 homepage = "https://github.com/paketo-buildpacks/ubi9-base-stack"
-maintainer = "Paketo Community"
+maintainer = "Paketo Buildpacks"
 
 platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
 

--- a/stacks/stack-nodejs-20/stack.toml
+++ b/stacks/stack-nodejs-20/stack.toml
@@ -1,6 +1,6 @@
 id = "io.buildpacks.stacks.ubi9"
 homepage = "https://github.com/paketo-buildpacks/ubi9-base-stack"
-maintainer = "Paketo Community"
+maintainer = "Paketo Buildpacks"
 
 platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
 

--- a/stacks/stack-nodejs-22/stack.toml
+++ b/stacks/stack-nodejs-22/stack.toml
@@ -1,6 +1,6 @@
 id = "io.buildpacks.stacks.ubi9"
 homepage = "https://github.com/paketo-buildpacks/ubi9-base-stack"
-maintainer = "Paketo Community"
+maintainer = "Paketo Buildpacks"
 
 platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
 

--- a/stacks/stack/stack.toml
+++ b/stacks/stack/stack.toml
@@ -1,6 +1,6 @@
 id = "io.buildpacks.stacks.ubi9"
 homepage = "https://github.com/paketo-buildpacks/ubi9-base-stack"
-maintainer = "Paketo Community"
+maintainer = "Paketo Buildpacks"
 
 platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR replaces any reference of the community keyword with the buildpack keyword

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
